### PR TITLE
migrate to gomodule/redigo from garyburd/redigo and introduce go modules

### DIFF
--- a/examples/fileserver.go
+++ b/examples/fileserver.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/mash/go-limiter"
 	"github.com/mash/go-limiter/redigostore"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/mash/go-limiter
+
+go 1.13
+
+require (
+	github.com/gomodule/redigo v1.7.0
+	github.com/soh335/go-test-redisserver v0.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gomodule/redigo v1.7.0 h1:ZKld1VOtsGhAe37E7wMxEDgAlGM5dvFY+DiOhSkhP9Y=
+github.com/gomodule/redigo v1.7.0/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/soh335/go-test-redisserver v0.1.0 h1:FZYs/CVmUFP1uHVq7avxU+HpRoFIv2JWzhdV/g2Hyk4=
+github.com/soh335/go-test-redisserver v0.1.0/go.mod h1:vofbm8mr+As7DkCPPNA9Jy/KOA6bBl50xd0VUkisMzY=

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/mash/go-limiter/redigostore"
-	"github.com/soh335/go-test-redisserver"
+	redistest "github.com/soh335/go-test-redisserver"
 )
 
 // will be nil if we're testing on wercker

--- a/redigostore/redigostore.go
+++ b/redigostore/redigostore.go
@@ -3,7 +3,7 @@ package redigostore
 import (
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type pool interface {


### PR DESCRIPTION
The garyburd/redigo is archived and the gomodule/redigo is the successor project of it. So we should switch to it.

In addition, I add go.mod and go.sum for supporting Go Modules. I would like you to place an appropriate license file after merging them and tag semver for go modules.